### PR TITLE
Fix throwing away final field

### DIFF
--- a/apache_log_parser/__init__.py
+++ b/apache_log_parser/__init__.py
@@ -215,6 +215,7 @@ class Parser:
                         self.log_line_regex += "(?P<"+name+">"+log_part_regex+")"
                         break
 
+        self.log_line_regex += '$'
         self._log_line_regex_raw = self.log_line_regex
         self.log_line_regex = re.compile(self.log_line_regex)
         self.names = tuple(self.names)

--- a/apache_log_parser/tests.py
+++ b/apache_log_parser/tests.py
@@ -72,7 +72,7 @@ class ApacheLogParserTestCase(unittest.TestCase):
             'remote_user': '-',
             'server_name': 'T1',
             'request_http_ver': '1.1',
-            'request_header_user_agent': '',
+            'request_header_user_agent': 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.76 Safari/537.36',
             'request_first_line': 'GET /content_images/3/American-University-in-Cairo-AUC.jpeg.jpg HTTP/1.1',
             'remote_logname': '-',
             'request_method': 'GET',


### PR DESCRIPTION
Since many of our patterns are implemented as `(.*?)` (i.e. a non-greedy match of zero or more characters), if there is nothing after that pattern, we are free to match zero characters and throw away everything else. So we should end the whole pattern with `$` to ensure we match against the whole line.

In fact this change caused `test_issue9` to fail, because the expectation was wrong. That pattern ends in `%{User-agent}i`, and the expectation wanted a `request_header_user_agent` of `''` (empty string). I fixed the test, which now asserts we capture the user agent correctly.